### PR TITLE
Release 3.9.0 (de-prerelease of 3.9.0-beta1)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.9.0-beta1] - 2026-07-02
+## [3.9.0] - 2026-07-06
 
 ### Added
 - **Top-level scalar projection: `Query<T>().Select(x => x.Member)` now returns `List<memberType>`.** Previously only `Select(x => new T { … })` (a same-entity column subset) was translated; the natural scalar spelling threw `NotSupportedException`. It now emits the **narrow `SELECT`** for that single member (as if `new T { Member = x.Member }`), materializes `T`, then projects the member in memory — so `Select(x => x.Id)` yields `List<int>`. Composes with `Where` + `OrderBy` (including a `[RemoteProperty]` join column) + `Skip`/`Take`, deferring the unprojected wide columns until after the Top-N (the performant call-list pattern: filter/order/page by a joined column, read back only the key). The member may be an own column or a self-contained computed attribute (`[JsonPath]`/`[SqlExpression]`/`[SubqueryAggregate]`). Applied in all four providers.

--- a/Funcular.Data.Orm.Core/Funcular.Data.Orm.Core.csproj
+++ b/Funcular.Data.Orm.Core/Funcular.Data.Orm.Core.csproj
@@ -13,10 +13,10 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <Version>3.9.0-beta1</Version>
+    <Version>3.9.0</Version>
     <AssemblyVersion>3.9.0.0</AssemblyVersion>
     <FileVersion>3.9.0.0</FileVersion>
-    <InformationalVersion>3.9.0-beta1</InformationalVersion>
+    <InformationalVersion>3.9.0</InformationalVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Funcular.Data.Orm.MySql/Funcular.Data.Orm.MySql.csproj
+++ b/Funcular.Data.Orm.MySql/Funcular.Data.Orm.MySql.csproj
@@ -12,10 +12,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>csharp;sql;orm;mysql;mariadb;entity;lambda;query</PackageTags>
     <Title>Funcular.FunkyORM.MySql</Title>
-    <Version>3.9.0-beta1</Version>
+    <Version>3.9.0</Version>
     <AssemblyVersion>3.9.0.0</AssemblyVersion>
     <FileVersion>3.9.0.0</FileVersion>
-    <InformationalVersion>3.9.0-beta1</InformationalVersion>
+    <InformationalVersion>3.9.0</InformationalVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <GenerateTargetFrameworkMonikerAttribute>true</GenerateTargetFrameworkMonikerAttribute>

--- a/Funcular.Data.Orm.PostgreSql/Funcular.Data.Orm.PostgreSql.csproj
+++ b/Funcular.Data.Orm.PostgreSql/Funcular.Data.Orm.PostgreSql.csproj
@@ -15,10 +15,10 @@
     <PackageIcon>funky-orm-lineart-256x256.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Title>Funcular.FunkyORM.PostgreSql</Title>
-    <Version>3.9.0-beta1</Version>
+    <Version>3.9.0</Version>
     <AssemblyVersion>3.9.0.0</AssemblyVersion>
     <FileVersion>3.9.0.0</FileVersion>
-    <InformationalVersion>3.9.0-beta1</InformationalVersion>
+    <InformationalVersion>3.9.0</InformationalVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <GenerateTargetFrameworkMonikerAttribute>true</GenerateTargetFrameworkMonikerAttribute>

--- a/Funcular.Data.Orm.SqlServer/Funcular.Data.Orm.SqlServer.csproj
+++ b/Funcular.Data.Orm.SqlServer/Funcular.Data.Orm.SqlServer.csproj
@@ -17,10 +17,10 @@
     <PackageTags>csharp;sql;orm;object-relational;database;entity;lambda;query</PackageTags>
     <PackageIcon>funky-orm-lineart-256x256.png</PackageIcon>
     <Title>Funcular.FunkyORM</Title>
-    <Version>3.9.0-beta1</Version>
+    <Version>3.9.0</Version>
     <AssemblyVersion>3.9.0.0</AssemblyVersion>
     <FileVersion>3.9.0.0</FileVersion>
-    <InformationalVersion>3.9.0-beta1</InformationalVersion>
+    <InformationalVersion>3.9.0</InformationalVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <GenerateTargetFrameworkMonikerAttribute>true</GenerateTargetFrameworkMonikerAttribute>

--- a/Funcular.Data.Orm.Sqlite/Funcular.Data.Orm.Sqlite.csproj
+++ b/Funcular.Data.Orm.Sqlite/Funcular.Data.Orm.Sqlite.csproj
@@ -13,10 +13,10 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>csharp;sql;orm;sqlite;entity;lambda;query;embedded;lightweight</PackageTags>
     <Title>Funcular.FunkyORM.Sqlite</Title>
-    <Version>3.9.0-beta1</Version>
+    <Version>3.9.0</Version>
     <AssemblyVersion>3.9.0.0</AssemblyVersion>
     <FileVersion>3.9.0.0</FileVersion>
-    <InformationalVersion>3.9.0-beta1</InformationalVersion>
+    <InformationalVersion>3.9.0</InformationalVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <SignAssembly>False</SignAssembly>
     <GenerateTargetFrameworkMonikerAttribute>true</GenerateTargetFrameworkMonikerAttribute>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
-> **Recent Changes**
-> * **v3.8.2-beta1**: 🐛 **Fix: aggregates dropped remote JOINs** — `Count`/`Any`/`All`/`Sum`/`Min`/`Max`/`Average` filtered by a `[RemoteProperty]`/`[RemoteKey]` (e.g. `Query<T>().Where(r => r.RemoteProp == x).Count()`) built the aggregate `FROM` without the required `LEFT JOIN`, failing at the engine. Fixed across all four providers (pre-existing defect).
-> * **v3.8.1-beta1**: 🔃 **View-replacing attributes in `OrderBy`, `Distinct()`, and projections** — order by `[JsonPath]`/`[SqlExpression]`/`[SubqueryAggregate]`/`[RemoteProperty]` (sorts by the resolved SQL, not a missing column), `Distinct()` → `SELECT DISTINCT`, and project the self-contained computed attributes in a custom `.Select(...)`. Gap closure across all four providers. See [JSON & Computed Column Attributes](#6-json--computed-column-attributes).
-> * **v3.8.0-beta1**: 🔐 **Row-Level Security & audit context (beta)** — prime per-request end-user identity onto each connection (even when the app connects as one identity) for RLS filtering and audit attribution. Full on SQL Server & PostgreSQL; attribution-only on MySQL. Shipping as a **beta** feature. See [Row-Level Security & Audit Context](#row-level-security--audit-context-v38) and the [Audit Context Runbook](docs/guides/AUDIT_CONTEXT_RUNBOOK.md).
-> * **v3.7.0**: ⚙️ **Stored procedure execution** — `ExecProcedure<T>` / `ExecScalar` / `ExecNonQuery` (+ async), with output parameters and `[Procedure]`/convention name resolution. Full on SQL Server & MySQL; `CALL`-based scalar/non-query on PostgreSQL; not supported on SQLite. See [Database Provider Differences](#database-provider-differences).
-> * **v3.6.0**: 🐬 **MySQL support** — a full `MySqlOrmDataProvider` (MIT-licensed MySqlConnector), bundled in the same `Funcular.Data.Orm` package with feature parity across providers.
-> * **v3.5.0**: 🗃️ **SQLite support** — a full file-backed, zero-config `SqliteOrmDataProvider`, bundled in the same package.
-> * **v3.2.1**: 🧩 **All four view-replacing attributes** — `[JsonPath]`, `[SqlExpression]`, `[SubqueryAggregate]`, `[JsonCollection]`.
+> **Recent Changes** — see [Changelog.md](Changelog.md) for full details.
+> * **v3.9.0**: 🎯 **Top-level scalar projection** — `Select(x => x.Member)` returns `List<memberType>` via a narrow `SELECT`; composes with filter / order-by (incl. a remote column) / paging.
+> * **v3.8.5-beta1**: 🎯 Explicit remote target authoritative on the final FK hop; documented the narrow-projection idiom.
+> * **v3.8.4-beta1**: 🐛 Fix: a `[RemoteProperty]` value column declared on a base class no longer throws `Invalid object name`.
+> * **v3.8.3-beta1**: 🐛 Fix: cold-cache remote column names; clear `NotSupportedException` for `GroupBy` and non-entity top-level `Select`.
+> * **v3.8.2-beta1**: 🐛 Fix: remote-filtered aggregates (`Count`/`Any`/`Sum`/…) now inject the required `LEFT JOIN`.
+> * **v3.8.1-beta1**: 🔃 View-replacing attributes in `OrderBy`, `Distinct()`, and projections.
+> * **v3.8.0-beta1**: 🔐 Row-Level Security & audit context (beta) — per-request end-user identity for RLS filtering and attribution.
+> * **v3.7.0**: ⚙️ Stored procedure execution — `ExecProcedure` / `ExecScalar` / `ExecNonQuery` (+ async).
+> * **v3.6.0**: 🐬 MySQL support — bundled in the same `Funcular.Data.Orm` package.
+> * **v3.5.0**: 🗃️ SQLite support — file-backed, zero-config, bundled in the same package.
+> * **v3.2.1**: 🧩 All four view-replacing attributes — `[JsonPath]`, `[SqlExpression]`, `[SubqueryAggregate]`, `[JsonCollection]`.
 
 
 # Funcular / Funky ORM: a speedy, lambda-powered .NET micro-ORM for MSSQL, PostgreSQL, MySQL & SQLite


### PR DESCRIPTION
De-prereleases the already-shipped **3.9.0-beta1** to stable **3.9.0**. Code is byte-identical to 3.9.0-beta1 (which passed CI + MySQL + PostgreSQL integration on `development/3.9`); this PR changes only version strings and docs.

## Changes
- Bump all five packages `3.9.0-beta1 → 3.9.0` (`Version` + `InformationalVersion`; `AssemblyVersion`/`FileVersion` already `3.9.0.0`).
- Changelog `[3.9.0-beta1]` header → `[3.9.0]` (body unchanged).
- README **Recent Changes**: trimmed every entry to a one-line hook, added the missing 3.8.3/3.8.4/3.8.5/3.9.0 lines, and added a `see Changelog.md for full details` link after the header.

## Deferred (logged for later)
- #12 — explicit `OrderBy(x => x.Id)` unqualified-`id` ambiguity on remote-join entities.
- #13 — untranslated LINQ operators (`Reverse`/`OfType`/`DefaultIfEmpty`) silently ignored.

Adversarial pass: `ecd7874` → CLEAN (version-only, behavior-identical to 3.9.0-beta1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)